### PR TITLE
fix: salvage safe parts from PR #26

### DIFF
--- a/src/core/browser_manager.py
+++ b/src/core/browser_manager.py
@@ -130,28 +130,16 @@ class BrowserManager:
             // 移除webdriver属性
             delete navigator.__proto__.webdriver;
             
-            // 禁用Service Worker注册以避免错误
-            if ('serviceWorker' in navigator) {
-                const originalRegister = navigator.serviceWorker.register;
-                navigator.serviceWorker.register = function() {
-                    return Promise.reject(new Error('Service Worker registration disabled'));
-                };
-                
-                // 也可以完全移除serviceWorker
-                Object.defineProperty(navigator, 'serviceWorker', {
-                    get: () => undefined
-                });
-            }
-            
-            // 捕获并忽略Service Worker相关错误
+            // 注意：不要禁用 Service Worker。
+            // 小红书创作平台的上传/编辑流程可能依赖 SW/缓存/路由模块；
+            // 禁用后可能出现“选完图片但不出预览/不进入编辑页”的卡死。
+            // 如果出现与 serviceWorker 相关的噪声报错，只做忽略，不拦截其注册。
             window.addEventListener('error', function(e) {
                 if (e.message && e.message.includes('serviceWorker')) {
                     e.preventDefault();
                     return false;
                 }
             });
-            
-            // 捕获未处理的Promise拒绝（Service Worker相关）
             window.addEventListener('unhandledrejection', function(e) {
                 if (e.reason && e.reason.message && e.reason.message.includes('serviceWorker')) {
                     e.preventDefault();

--- a/src/core/write_xiaohongshu.py
+++ b/src/core/write_xiaohongshu.py
@@ -2331,6 +2331,11 @@ class XiaohongshuPoster:
             # 输入标题
             print("输入标题...")
             try:
+                if title and len(title) > 20:
+                    original_title = title
+                    title = title[:20]
+                    print(f"⚠️ 标题超 20 字，已自动截断: '{original_title}' -> '{title}'")
+
                 # 使用具体的标题选择器
                 title_selectors = [
                     "input.d-text[placeholder='填写标题会有更多赞哦～']",


### PR DESCRIPTION
## Summary
- keep Service Worker enabled in browser stealth setup
- enforce Xiaohongshu title length <= 20 characters before fill
- intentionally leave PR #26 open and only extract low-risk reusable parts

## Why
PR #26 contains useful fixes, but it also carries hard-coded profile/test-script changes and conflicts with the newer publish flow already on `main`.

This PR only ports the low-risk parts that are safe to merge independently.

## Verification
- `python3 -m py_compile src/core/browser_manager.py src/core/write_xiaohongshu.py`
- reviewed diff against PR #26 manually